### PR TITLE
add DestructureRef

### DIFF
--- a/tests/10-destructure-ref.rs
+++ b/tests/10-destructure-ref.rs
@@ -1,0 +1,23 @@
+#![allow(dead_code)]
+
+use destructure::DestructureRef;
+
+#[derive(DestructureRef)]
+pub struct Book<T> {
+    name: String,
+    author: String,
+    tags: Vec<T>,
+}
+
+#[allow(unused)]
+fn main() {
+    let book: Book<String> = Book {
+        name: "Drive".to_owned(),
+        author: "Literally Me".to_owned(),
+        tags: Vec::new(),
+    };
+
+    let DestructBookRef { name, author, tags } = book.as_destruct();
+
+    drop(book);
+}


### PR DESCRIPTION
This PR adds `DestructureRef` derive macro as an alternative to plain `Destructure` in case no ownership is passed; since it works by reference and no mutation is intended, it provides only `as_destruct` method and basically adds a view to the existing value with field by field access as shared references